### PR TITLE
Add Cypress 3.7.0

### DIFF
--- a/3.7.0/Dockerfile
+++ b/3.7.0/Dockerfile
@@ -1,0 +1,34 @@
+# direct copy of the following, but as user node
+# https://github.com/cypress-io/cypress-docker-images/blob/master/included/3.7.0/Dockerfile
+FROM cypress/browsers:node12.6.0-chrome77
+
+# BEGIN_DIFF
+RUN \
+  mkdir /test_as_node_user && \
+  chown -R node /test_as_node_user && \
+  chown -R node /usr/local
+WORKDIR /test_as_node_user
+USER node
+# END_DIFF
+
+# avoid too many progress messages
+# https://github.com/cypress-io/cypress/issues/1243
+ENV CI=1
+ARG CYPRESS_VERSION="3.7.0"
+
+RUN echo "whoami: $(whoami)"
+RUN npm config -g set user $(whoami)
+RUN npm install -g "cypress@${CYPRESS_VERSION}"
+RUN cypress verify
+
+# Cypress cache and installed version
+RUN cypress cache path
+RUN cypress cache list
+
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "user:            $(whoami) \n"
+
+ENTRYPOINT ["cypress", "run"]

--- a/3.7.0/README.md
+++ b/3.7.0/README.md
@@ -1,0 +1,18 @@
+# cypress/included:3.7.0
+
+Read [Run Cypress with a single Docker command](https://www.cypress.io/blog/2019/05/02/run-cypress-with-a-single-docker-command/)
+
+## Run tests
+
+```shell
+$ docker run -it -v $PWD:/e2e -w /e2e cypress/included:3.7.0
+# runs Cypress tests from the current folder
+```
+
+## Show Cypress version
+
+```shell
+$ docker run -it -v $PWD:/e2e -w /e2e --entrypoint cypress cypress/included:3.7.0 --version
+Cypress package version: 3.7.0
+Cypress binary version: 3.7.0
+```

--- a/3.7.0/build.sh
+++ b/3.7.0/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=dinodna/cypress-included-as-node-user:3.7.0
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
This adds the `include` 3.7.0 from https://github.com/cypress-io/cypress-docker-images/tree/master/included/3.7.0 with the same 3.6.1 user changes in this repo.